### PR TITLE
Change Dockerfile base from alpine to bullseye

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 datadirs
 yarn-error.log
 *.env
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM node:16-alpine as build
+FROM node:16-bullseye as build
 WORKDIR /usr/app
-RUN apk update && apk add --no-cache bash git yarn && rm -rf /var/cache/apk/*
+RUN apt-get update
 
 RUN git clone --depth 1 --branch main https://github.com/ProjectOpenSea/seaport-gossip.git
 
 WORKDIR /usr/app/seaport-gossip
 RUN yarn
 
-FROM node:16-alpine
+FROM node:16-bullseye
 WORKDIR /usr/app
 COPY --from=build /usr/app .
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

Exploring the repo and got the following on build:

```
$ docker build -t seaport-gossip:latest .
[+] Building 37.2s (9/10)                                                                                                                                                                                                                                
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                0.0s
 => => transferring dockerfile: 737B                                                                                                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/node:16-alpine                                                                                                                                                                                   0.6s
 => [stage-1 1/3] FROM docker.io/library/node:16-alpine@sha256:15dd66f723aab8b367abc7ac6ed25594ca4653f2ce49ad1505bfbe740ad5190e                                                                                                                     0.0s
 => CACHED [stage-1 2/3] WORKDIR /usr/app                                                                                                                                                                                                           0.0s
 => CACHED [build 3/6] RUN apk update && apk add --no-cache bash git yarn && rm -rf /var/cache/apk/*                                                                                                                                                0.0s
 => CACHED [build 4/6] RUN git clone --depth 1 --branch main https://github.com/ProjectOpenSea/seaport-gossip.git                                                                                                                                   0.0s
 => CACHED [build 5/6] WORKDIR /usr/app/seaport-gossip                                                                                                                                                                                              0.0s
 => ERROR [build 6/6] RUN yarn                                                                                                                                                                                                                     36.5s
------                                                                                                                                                                                                                                                   
 > [build 6/6] RUN yarn:                                                                                                                                                                                                                                 
#9 0.287 yarn install v1.22.19                                                                                                                                                                                                                           
#9 0.368 [1/5] Validating package.json...                                                                                                                                                                                                                
#9 0.371 [2/5] Resolving packages...                                                                                                                                                                                                                     
#9 0.590 [3/5] Fetching packages...                                                                                                                                                                                                                      
#9 20.27 [4/5] Linking dependencies...
#9 20.27 warning "@chainsafe/libp2p-gossipsub > @libp2p/interface-connection > @multiformats/multiaddr > dns-over-http-resolver > native-fetch@4.0.2" has unmet peer dependency "undici@*".
#9 20.28 warning " > typegraphql-prisma@0.21.5" has unmet peer dependency "tslib@^2.4.0".
#9 25.70 [5/5] Building fresh packages...
#9 27.90 $ yarn fixStreamJSTypeImports && yarn build
#9 28.09 yarn run v1.22.19
#9 28.13 $ npx json -I -f node_modules/@opensea/stream-js/package.json -e "this.exports.types='./dist/index.d.ts'" && npx replace "client'" "client.js'" node_modules/@opensea/stream-js/dist/index.d.ts && npx replace "types'" "types.js'" node_modules/@opensea/stream-js/dist/index.d.ts
#9 29.61 npm WARN exec The following package was not found and will be installed: json@11.0.0
#9 29.95 json: updated "node_modules/@opensea/stream-js/package.json" in-place
#9 29.96 npm notice 
#9 29.96 npm notice New major version of npm available! 8.19.2 -> 9.1.2
#9 29.96 npm notice Changelog: <https://github.com/npm/cli/releases/tag/v9.1.2>
#9 29.96 npm notice Run `npm install -g npm@9.1.2` to update!
#9 29.96 npm notice 
#9 31.44 npm WARN exec The following package was not found and will be installed: replace@1.2.2
#9 32.78 node_modules/@opensea/stream-js/dist/index.d.ts
#9 32.78  1: export * from './client.js';
#9 34.52 node_modules/@opensea/stream-js/dist/index.d.ts
#9 34.52  2: export * from './types.js';
#9 34.53 Done in 6.44s.
#9 34.64 yarn run v1.22.19
#9 34.68 $ yarn prisma:generate && yarn build:ts
#9 34.82 $ SKIP_PRISMA_VERSION_CHECK=true prisma generate
#9 35.40 Error: Unknown binaryTarget linux-arm64-openssl-undefined and no custom engine files were provided
#9 35.97 error Command failed with exit code 1.
#9 35.97 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
#9 35.99 error Command failed with exit code 1.
#9 35.99 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
#9 36.02 error Command failed with exit code 1.
#9 36.02 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
------
executor failed running [/bin/sh -c yarn]: exit code: 1
```

Specifically, the `prisma generate` line fails.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Found [this thread on prisma's gh from a few days ago](https://github.com/prisma/prisma/issues/16256) about how they're going to start raising this as an explicit error on slim docker images.

I had success building with the bullseye variant, but lmk if you think something else would be better 
