### PR TITLE
PRTCL-727: Make Seaport Gossip private package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "seaport-gossip",
+  "private": true,
   "version": "0.0.1",
   "description": "A peer-to-peer network for sharing Seaport orders.",
   "author": "OpenSea",


### PR DESCRIPTION
This prevents seaport gossip from being uploaded to npm. This is not a package anyone should depend on directly.

<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
